### PR TITLE
TRITON-2344 Agents should include the build stamp in the image version string

### DIFF
--- a/manifests/gz-tools.manifest.tmpl
+++ b/manifests/gz-tools.manifest.tmpl
@@ -3,7 +3,7 @@
   "uuid": "UUID",
   "owner": "00000000-0000-0000-0000-000000000000",
   "name": "NAME",
-  "version": "VERSION",
+  "version": "VERSION-BUILDSTAMP",
   "state": "active",
   "disabled": false,
   "public": false,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "usb-headnode",
   "description": "Build SDC headnode images",
-  "version": "3.2.0",
-  "author": "Joyent (joyent.com)",
+  "version": "3.3.0",
+  "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {
     "assert-plus": "^0.1.5",


### PR DESCRIPTION
I decided I want the gz-tools image to also include the build stamp. package.json version bump is for the update to sb(create|upload), which should have bumped the version but didn't.