### PR TITLE
LINUXCN-14 Restart triton-lxd service when setting up LinuxCN

### DIFF
--- a/scripts/joysetup.sh
+++ b/scripts/joysetup.sh
@@ -755,7 +755,7 @@ setup_datasets()
             # Linux mounts to /var
             zfs set mountpoint=/var "${VARDS}" || \
             fatal "failed to set the mountpoint for ${VARDS}"
-            # Restart triton-lxd service so imgadm list succeeds later
+            # Restart triton-lxd service now that /var is mounted properly
             systemctl restart triton-lxd.service
         fi
 

--- a/scripts/joysetup.sh
+++ b/scripts/joysetup.sh
@@ -755,6 +755,8 @@ setup_datasets()
             # Linux mounts to /var
             zfs set mountpoint=/var "${VARDS}" || \
             fatal "failed to set the mountpoint for ${VARDS}"
+            # Restart triton-lxd service so imgadm list succeeds later
+            systemctl restart triton-lxd.service
         fi
 
         zfs set atime=on "${VARDS}" || \


### PR DESCRIPTION
Resolves the following error that occurs after running `sdc-server setup`:

```
[2023-04-17T18:46:06Z] ./joysetup.sh:916: setup_imgadm(): imgadm list -H
imgadm list: error (InternalError): could not run "lxc image list":
        command: /usr/local/lxd/bin/lxc image list --format json
        exit status: 1
        stdout:

        stderr:
Error: Get "<http://unix.socket/1.0":> dial unix /var/lib/lxd/unix.socket: connect: connection refused
```

Tested by manually changing joysetup.sh on a local Triton. Also confirmed it had no impact on setting up SmartOS CNs.
