### PR TITLE
LINUXCN-25 Use ntpdig on LinuxCN instead of ntpdate

### DIFF
--- a/scripts/joysetup.sh
+++ b/scripts/joysetup.sh
@@ -250,8 +250,13 @@ function check_ntp
     set -o errexit
 
     # check absolute value of integer portion of offset is reasonable.
-    offset=$(ntpdate -q "${servers}" | grep "offset .* sec" | \
-        sed -e "s/^.*offset //" | cut -d' ' -f1 | tr -d '-' | cut -d'.' -f1)
+    if [[ $OS_TYPE == "Linux" ]]; then
+        offset=$(ntpdig -j "${servers}" | json .offset | tr -d '-' | \
+            cut -d'.' -f1)
+    else
+        offset=$(ntpdate -q "${servers}" | grep "offset .* sec" | \
+            sed -e "s/^.*offset //" | cut -d' ' -f1 | tr -d '-' | cut -d'.' -f1)
+    fi
 
     if [[ -z ${offset} ]]; then
         fatal "Unable to set system clock, fix NTP settings and try again."

--- a/scripts/joysetup.sh
+++ b/scripts/joysetup.sh
@@ -251,8 +251,10 @@ function check_ntp
 
     # check absolute value of integer portion of offset is reasonable.
     if [[ $OS_TYPE == "Linux" ]]; then
-        offset=$(ntpdig -j "${servers}" | json .offset | tr -d '-' | \
-            cut -d'.' -f1)
+        # Get the absolute value of the offset and round it down to the nearest
+        # whole number
+        offset=$(ntpdig -j "${servers}" | \
+            json -e 'this.offset=Math.floor(Math.abs(this.offset))' offset)
     else
         offset=$(ntpdate -q "${servers}" | grep "offset .* sec" | \
             sed -e "s/^.*offset //" | cut -d' ' -f1 | tr -d '-' | cut -d'.' -f1)


### PR DESCRIPTION
In Debian 12 `ntpdate` output has changed and the binary has been replaced with a shell script that calls `ntpdig`. Since `ntpdig` is being called anyway, and it has json output, use that instead on Linux CN.

See [LINUXCN-25](https://mnx.atlassian.net/browse/LINUXCN-25) for testing notes.

[LINUXCN-25]: https://mnx.atlassian.net/browse/LINUXCN-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ